### PR TITLE
Add feature: require api key if allow sub-accounts feature is enabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # ADD THIS KEY ON .env ROOT FILE
+ASAAS_ALLOW_SUB_ACCOUNTS=false
 ASAAS_API_VERSION=v3
 
 ASAAS_SANDBOX_BASE_URL=https://sandbox.asaas.com/api/

--- a/config/asaas-php.php
+++ b/config/asaas-php.php
@@ -5,6 +5,7 @@ $sandboxBaseUrl = env('ASAAS_SANDBOX_BASE_URL', 'https://sandbox.asaas.com/api/'
 $productionBaseUrl = env('ASAAS_PRODUCTION_BASE_URL', 'https://api.asaas.com/');
 
 return [
+    'allow_sub_accounts' => env('ASAAS_ALLOW_SUB_ACCOUNTS', false),
     'version' => $version,
     'environment' => [
         'sandbox' => [

--- a/src/Concerns/HasClient.php
+++ b/src/Concerns/HasClient.php
@@ -2,16 +2,26 @@
 
 namespace TioJobs\AsaasPhp\Concerns;
 
+use Exception;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use TioJobs\AsaasPhp\Contracts\Core\AsaasInterface;
+use TioJobs\AsaasPhp\Exceptions\ExceptionRequiredApiKey;
 
 trait HasClient
 {
     use HasToken;
 
+    /**
+     * @throws ExceptionRequiredApiKey
+     */
     protected function client(): PendingRequest
     {
+
+        if($this->hasAllowSubAccount() && empty($this->apiKey)){
+            throw new ExceptionRequiredApiKey('You must provide an API key. You can do so by passing it as a parameter to the constructor or methods (e.g., make(apiKey) or withKey(apiKey)).');
+        }
+
         return Http::baseUrl($this->resolveBaseUrl())->withHeader('access_token', $this->apiKey);
     }
 
@@ -20,13 +30,24 @@ trait HasClient
         return config("asaas-php.environment.{$this->getMode()}.url"); // @phpstan-ignore-line
     }
 
-    public static function make(string $apiKey = '', string $mode = ''): self
+    protected function hasAllowSubAccount(): bool
+    {
+        return config('asaas-php.allow_sub_accounts'); // @phpstan-ignore-line
+    }
+
+    public function make(string $apiKey = '', string $mode = ''): self
     {
         return new self($apiKey, $mode);
     }
 
+    public function withKey(string $apiKey, string $mode = ''): self
+    {
+        return $this->make($apiKey, $mode);
+    }
+
     /**
      * @return array<string, mixed>
+     * @throws ExceptionRequiredApiKey
      */
     public function get(AsaasInterface $resource): array
     {
@@ -35,13 +56,16 @@ trait HasClient
                 ->get($resource->getPath())
                 ->throw()
                 ->json();
-        } catch (\Exception $exception) {
+        } catch (ExceptionRequiredApiKey $apiKeyException) {
+            throw $apiKeyException;
+        } catch (Exception $exception) {
             return ['error' => $exception->getMessage()];
         }
     }
 
     /**
      * @return array<string, mixed>
+     * @throws ExceptionRequiredApiKey
      */
     public function post(AsaasInterface $resource): array
     {
@@ -50,13 +74,16 @@ trait HasClient
                 ->post($resource->getPath(), $resource->getData())
                 ->throw()
                 ->json();
-        } catch (\Exception $exception) {
+        } catch (ExceptionRequiredApiKey $apiKeyException) {
+            throw $apiKeyException;
+        } catch (Exception $exception) {
             return ['error' => $exception->getMessage()];
         }
     }
 
     /**
      * @return array<string, mixed>
+     * @throws ExceptionRequiredApiKey
      */
     public function put(AsaasInterface $resource): array
     {
@@ -65,13 +92,16 @@ trait HasClient
                 ->put($resource->getPath(), $resource->getData())
                 ->throw()
                 ->json();
-        } catch (\Exception $exception) {
+        } catch (ExceptionRequiredApiKey $apiKeyException) {
+            throw $apiKeyException;
+        } catch (Exception $exception) {
             return ['error' => $exception->getMessage()];
         }
     }
 
     /**
      * @return array<string, mixed>
+     * @throws ExceptionRequiredApiKey
      */
     public function delete(AsaasInterface $resource): array
     {
@@ -80,13 +110,16 @@ trait HasClient
                 ->delete($resource->getPath())
                 ->throw()
                 ->json();
-        } catch (\Exception $exception) {
+        } catch (ExceptionRequiredApiKey $apiKeyException) {
+            throw $apiKeyException;
+        } catch (Exception $exception) {
             return ['error' => $exception->getMessage()];
         }
     }
 
     /**
      * @return array<string, mixed>
+     * @throws ExceptionRequiredApiKey
      */
     public function upload(AsaasInterface $resource): array
     {
@@ -96,7 +129,9 @@ trait HasClient
                 ->post($resource->getPath(), $resource->getData())
                 ->throw()
                 ->json();
-        } catch (\Exception $exception) {
+        } catch (ExceptionRequiredApiKey $apiKeyException) {
+            throw $apiKeyException;
+        } catch (Exception $exception) {
             return ['error' => $exception->getMessage()];
         }
     }

--- a/src/Concerns/HasToken.php
+++ b/src/Concerns/HasToken.php
@@ -6,7 +6,7 @@ trait HasToken
 {
     use HasMode;
 
-    protected function withToken(): void
+    protected function injectApiKey(): void
     {
         $this->apiKey ??= config("asaas-php.environment.{$this->getMode()}.key"); // @phpstan-ignore-line
     }

--- a/src/Core/Asaas.php
+++ b/src/Core/Asaas.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TioJobs\AsaasPhp\Core;
 
+use Exception;
 use TioJobs\AsaasPhp\Concerns\HasClient;
 use TioJobs\AsaasPhp\Resource\BankResource;
 use TioJobs\AsaasPhp\Resource\ChargeResource;
@@ -15,9 +16,10 @@ class Asaas
 {
     use HasClient;
 
+
     public function __construct(public string $apiKey = '', public string $mode = '')
     {
-        $this->withToken();
+        $this->injectApiKey();
     }
 
     public function customer(): CustomerResource

--- a/src/Exceptions/ExceptionRequiredApiKey.php
+++ b/src/Exceptions/ExceptionRequiredApiKey.php
@@ -1,0 +1,9 @@
+<?php
+namespace TioJobs\AsaasPhp\Exceptions;
+
+use Exception;
+
+class ExceptionRequiredApiKey extends Exception
+{
+
+}

--- a/src/Facades/AsaasPhp.php
+++ b/src/Facades/AsaasPhp.php
@@ -7,6 +7,7 @@ use TioJobs\AsaasPhp\Core\Asaas;
 
 /**
  * @method static Asaas make(string $apiKey = '', string $mode= '')
+ * @method static Asaas withKey(string $apiKey, string $mode= '')
  */
 class AsaasPhp extends Facade
 {

--- a/tests/Feature/Core/AsaasTest.php
+++ b/tests/Feature/Core/AsaasTest.php
@@ -1,4 +1,15 @@
 <?php
+use Illuminate\Support\Facades\Config;
+use TioJobs\AsaasPhp\Exceptions\ExceptionRequiredApiKey;
+use TioJobs\AsaasPhp\Facades\AsaasPhp;
+
+it('api key is required when allowing sub-accounts', function(){
+
+    Config::set('asaas-php.allow_sub_accounts', true);
+
+    AsaasPhp::withKey('')->customer()->get(id: '123');
+
+})->throws(ExceptionRequiredApiKey::class, 'You must provide an API key. You can do so by passing it as a parameter to the constructor or methods (e.g., make(apiKey) or withKey(apiKey)).');
 
 todo('check list method');
 todo('check create method');

--- a/tests/Feature/Customers/CreateCustomerTest.php
+++ b/tests/Feature/Customers/CreateCustomerTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use TioJobs\AsaasPhp\Facades\AsaasPhp;
+
 test('create new customer', function () {
     $customer = generateCustomer();
 
-    $response = asaasPhp()->customer()->create(...$customer);
+    $response = AsaasPhp::withKey(config('asaas-php.environment.sandbox.key'), 'sandbox')->customer()->create(...$customer);
 
     expect(json_encode($response))
         ->json()

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -32,6 +32,10 @@ function generateCustomer(): array
 
 function asaasPhp(?string $apiKey = null, string $mode = 'sandbox'): Asaas
 {
+    if(config('asaas-php.allow_sub_accounts')){
+        return new Asaas((string) $apiKey, $mode);
+    }
+
     return new Asaas($apiKey ?? config('asaas-php.environment.sandbox.key'), $mode);
 }
 


### PR DESCRIPTION
Regarding the name of the environment variable, for now it is **ASAAS_ALLOW_SUB_ACCOUNTS** as I had talked to **Tio Jobs** on WhatsApp, but I saw @dansysanalyst  suggestion and I agree that the name **ALWAYS_REQUIRE_API_KEY** is more cohesive for this.