### PR TITLE
chore: removed unecessary stricts

### DIFF
--- a/src/Resource/NotificationResource.php
+++ b/src/Resource/NotificationResource.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace TioJobs\AsaasPhp\Resource;
 
 use TioJobs\AsaasPhp\DataTransferObjects\Notifications\UpdateNotificationDTO;


### PR DESCRIPTION
### REMOVED UNECESSARY STRICTS
I saw that file xxxx was used declare(strict_types=1), but isn't recommended when you develop Laravel Packages!.